### PR TITLE
Make creating directories lazy in RootWorkspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/workspace/compare/release-2.0.2...master
 
+### Fixed
+- Stop creating directories just by creating instance of `RootWorkspace`, make it lazy.
+
 ## [2.0.2] - 2019-11-04
 [2.0.2]: https://github.com/atlassian/workspace/compare/release-2.0.1...release-2.0.2
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,7 @@ dependencies {
 
     listOf(
         "junit:junit:4.12",
-        "org.hamcrest:hamcrest-library:1.3",
-        "org.assertj:assertj-core:3.10.0"
+        "org.assertj:assertj-core:3.23.1"
     ).forEach { testCompile(it) }
 }
 

--- a/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
@@ -2,6 +2,6 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 junit:junit:4.12
-org.assertj:assertj-core:3.10.0
+net.bytebuddy:byte-buddy:1.12.10
+org.assertj:assertj-core:3.23.1
 org.hamcrest:hamcrest-core:1.3
-org.hamcrest:hamcrest-library:1.3

--- a/gradle/dependency-locks/testCompile.lockfile
+++ b/gradle/dependency-locks/testCompile.lockfile
@@ -2,6 +2,6 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 junit:junit:4.12
-org.assertj:assertj-core:3.10.0
+net.bytebuddy:byte-buddy:1.12.10
+org.assertj:assertj-core:3.23.1
 org.hamcrest:hamcrest-core:1.3
-org.hamcrest:hamcrest-library:1.3

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -8,12 +8,12 @@ com.jcraft:jzlib:1.1.1
 commons-codec:commons-codec:1.9
 commons-logging:commons-logging:1.2
 junit:junit:4.12
+net.bytebuddy:byte-buddy:1.12.10
 org.apache.httpcomponents:httpclient:4.5.2
 org.apache.httpcomponents:httpcore:4.4.4
-org.assertj:assertj-core:3.10.0
+org.assertj:assertj-core:3.23.1
 org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
 org.hamcrest:hamcrest-core:1.3
-org.hamcrest:hamcrest-library:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.20
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.20
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.20

--- a/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -8,12 +8,12 @@ com.jcraft:jzlib:1.1.1
 commons-codec:commons-codec:1.9
 commons-logging:commons-logging:1.2
 junit:junit:4.12
+net.bytebuddy:byte-buddy:1.12.10
 org.apache.httpcomponents:httpclient:4.5.2
 org.apache.httpcomponents:httpcore:4.4.4
-org.assertj:assertj-core:3.10.0
+org.assertj:assertj-core:3.23.1
 org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
 org.hamcrest:hamcrest-core:1.3
-org.hamcrest:hamcrest-library:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.20
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.20
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.20

--- a/gradle/dependency-locks/testRuntime.lockfile
+++ b/gradle/dependency-locks/testRuntime.lockfile
@@ -2,6 +2,6 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 junit:junit:4.12
-org.assertj:assertj-core:3.10.0
+net.bytebuddy:byte-buddy:1.12.10
+org.assertj:assertj-core:3.23.1
 org.hamcrest:hamcrest-core:1.3
-org.hamcrest:hamcrest-library:1.3

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -8,12 +8,12 @@ com.jcraft:jzlib:1.1.1
 commons-codec:commons-codec:1.9
 commons-logging:commons-logging:1.2
 junit:junit:4.12
+net.bytebuddy:byte-buddy:1.12.10
 org.apache.httpcomponents:httpclient:4.5.2
 org.apache.httpcomponents:httpcore:4.4.4
-org.assertj:assertj-core:3.10.0
+org.assertj:assertj-core:3.23.1
 org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
 org.hamcrest:hamcrest-core:1.3
-org.hamcrest:hamcrest-library:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.20
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.20
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.20

--- a/src/main/kotlin/com/atlassian/performance/tools/workspace/api/RootWorkspace.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/workspace/api/RootWorkspace.kt
@@ -19,20 +19,24 @@ class RootWorkspace(
      * The directory containing the root workspace.
      * Embedded within [parent].
      */
-    val directory: Path = parent
-        .resolve("jpt-workspace")
-        .toAbsolutePath()
-        .normalize()
-        .ensureDirectory()
+    val directory: Path by lazy {
+        parent
+            .resolve("jpt-workspace")
+            .toAbsolutePath()
+            .normalize()
+            .ensureDirectory()
+    }
 
     /**
      * The current task workspace unique to this root workspace instance.
      */
-    val currentTask: TaskWorkspace = isolateTask(
-        label = System.getenv("bamboo_buildResultKey")
-            ?: LocalDateTime.now()
-                .format(ISO_LOCAL_DATE_TIME)
-    )
+    val currentTask: TaskWorkspace by lazy {
+        isolateTask(
+            label = System.getenv("bamboo_buildResultKey")
+                ?: LocalDateTime.now()
+                    .format(ISO_LOCAL_DATE_TIME)
+        )
+    }
 
     /**
      * Finds a new workspaces for a task.

--- a/src/test/kotlin/com/atlassian/performance/tools/report/GitRepoTest.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/report/GitRepoTest.kt
@@ -2,10 +2,8 @@ package com.atlassian.performance.tools.report
 
 import com.atlassian.performance.tools.workspace.api.git.GitRepo
 import com.atlassian.performance.tools.workspace.git.LocalGitRepo
+import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.jgit.internal.storage.file.FileRepository
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.notNullValue
-import org.junit.Assert.assertThat
 import org.junit.Test
 import java.io.File
 import java.nio.file.Path
@@ -15,40 +13,36 @@ class GitRepoTest {
     @Test
     fun shouldFindRepo() {
         val repo = GitRepo.findFromCurrentDirectory()
-
-        assertThat(repo, notNullValue())
+        assertThat(repo).isNotNull
     }
 
     @Test
-    fun shouldPrintBranchHead() {
+    fun shouldGetBranchHead() {
         val testResource = "on-branch.git"
         val repo = getTestRepo(testResource)
 
         val head = repo.getHead()
 
-        assertThat(head, equalTo("8b1171cbf2f51c76e4da0dd9ff563761b1f191ab"))
-        println("Got Git branch HEAD: $head")
+        assertThat(head).isEqualTo("8b1171cbf2f51c76e4da0dd9ff563761b1f191ab")
     }
 
     @Test
-    fun shouldPrintBranchHeadForPackedRef() {
+    fun shouldGetBranchHeadForPackedRef() {
         val testResource = "on-branch-packed-refs.git"
         val repo = getTestRepo(testResource)
 
         val head = repo.getHead()
 
-        assertThat(head, equalTo("14f2d8ec89d8dd885f7b561dc6ec823e402d551e"))
-        println("Got Git branch HEAD: $head")
+        assertThat(head).isEqualTo("14f2d8ec89d8dd885f7b561dc6ec823e402d551e")
     }
 
     @Test
-    fun shouldPrintCommitHead() {
+    fun shouldGetCommitHead() {
         val repo = getTestRepo("on-commit.git")
 
         val head = repo.getHead()
 
-        assertThat(head, equalTo("bc8578c511a558dbf542adc23fa1a33b24695c1f"))
-        println("Got Git commit HEAD: $head")
+        assertThat(head).isEqualTo("bc8578c511a558dbf542adc23fa1a33b24695c1f")
     }
 
     @Test
@@ -60,8 +54,7 @@ class GitRepoTest {
 
         val head = repo.getHead()
 
-        assertThat(head, equalTo("14f2d8ec89d8dd885f7b561dc6ec823e402d551e"))
-        println("Got Git commit HEAD: $head")
+        assertThat(head).isEqualTo("14f2d8ec89d8dd885f7b561dc6ec823e402d551e")
     }
 
     /**
@@ -73,19 +66,19 @@ class GitRepoTest {
      * full path.
      */
     private fun configureWorktree(): Path {
-        val worktreeTestDotGit = File(
-                javaClass.getResource("worktree/dotgit").toURI()
-        )
+        val worktreeTestDotGit = File(javaClass.getResource("worktree/dotgit").toURI())
 
         val worktreeFolder = worktreeTestDotGit.parentFile.toPath()
         val worktreeDotGit = worktreeFolder.resolve(".git")
-        worktreeDotGit.toFile().writeText("gitdir: "
-            + worktreeFolder.parent.toAbsolutePath()
-            .resolve("main")
-            .resolve(".git")
-            .resolve("worktrees")
-            .resolve("worktree")
-            .toString())
+        worktreeDotGit.toFile().writeText(
+            "gitdir: "
+                + worktreeFolder.parent.toAbsolutePath()
+                .resolve("main")
+                .resolve(".git")
+                .resolve("worktrees")
+                .resolve("worktree")
+                .toString()
+        )
         return worktreeFolder
     }
 
@@ -95,22 +88,14 @@ class GitRepoTest {
      * copy it and rename it at runtime.
      */
     private fun configureMain(): Path {
-        val mainTestDotGit = File(
-                javaClass.getResource("main/dotgit").toURI()
-        )
+        val mainTestDotGit = File(javaClass.getResource("main/dotgit").toURI())
         val mainFolder = mainTestDotGit.parentFile.toPath()
         val mainDotGit = mainFolder.resolve(".git")
         mainTestDotGit.copyRecursively(mainDotGit.toFile(), true)
         return mainFolder
     }
 
-    private fun getTestRepo(
-        testResource: String
-    ): GitRepo = LocalGitRepo(
-        FileRepository(
-            File(
-                javaClass.getResource(testResource).toURI()
-            )
-        )
+    private fun getTestRepo(testResource: String): GitRepo = LocalGitRepo(
+        FileRepository(File(javaClass.getResource(testResource).toURI()))
     )
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/report/RootWorkspaceTest.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/report/RootWorkspaceTest.kt
@@ -1,0 +1,30 @@
+package com.atlassian.performance.tools.report
+
+import com.atlassian.performance.tools.workspace.api.RootWorkspace
+import org.assertj.core.util.Files
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class RootWorkspaceTest {
+
+    @Test
+    fun shouldCreatingNewInstanceHaveNoSideEffect() {
+        // given
+        val tempDir = Files.newTemporaryFolder()
+        // when
+        RootWorkspace(parent = tempDir.toPath())
+        // then
+        assertThat(tempDir).isEmptyDirectory()
+    }
+
+    @Test
+    fun shouldCreateDirWhenGetCurrentTask() {
+        // given
+        val tempDir = Files.newTemporaryFolder()
+        // when
+        RootWorkspace(parent = tempDir.toPath()).currentTask
+        // then
+        assertThat(tempDir).isNotEmptyDirectory()
+    }
+
+}


### PR DESCRIPTION
That stops from creating directories just by creating instance of RootWorkspace